### PR TITLE
Save on input event.

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -12,7 +12,7 @@
     "regex": "",
     "url": ""
   },
-  "preferencesPage": "src/preferences.html",
+  "preferencesPage": "src/preferences/preferences.html",
   "sidebarTab": { "name": "File Name Search" },
   "version": "1.0.0"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,15 @@ import json from "@eslint/json";
 
 export default defineConfig([
     globalIgnores(["coverage/"]),
-    { languageOptions: { globals: { ...globals.node, iina: true } } },
+    {
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                iina: true,
+            },
+        },
+    },
     { files: ["**/*.js", "**/*.cjs", "**/*.mjs"], plugins: { js }, extends: ["js/recommended"] },
     {
         files: ["**/*.json"],

--- a/src/preferences/preferences.html
+++ b/src/preferences/preferences.html
@@ -1,7 +1,7 @@
-<!-- TODO save on keyUp -->
 <html>
 
 <head>
+    <script src="preferences.js" defer></script>
 </head>
 
 <body>

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -16,5 +16,5 @@ function dispatchChangeEvent(element) {
 
 // Register event listeners.
 document.querySelectorAll('input[type="text"]').forEach((input) => {
-    input.addEventListener("keyup", (event) => dispatchChangeEvent(event.target));
+    input.addEventListener("input", (event) => dispatchChangeEvent(event.target));
 });

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -1,0 +1,20 @@
+/**
+ * Main javascript file for the plugin's preferences tab.
+ */
+
+/**
+ * Programmatically trigger the "change" event on an HTML element.
+ *
+ * IINA saves text inputs in the "change" event. Triggering this for additional events for improved responsiveness.
+ *
+ * @param {Element} element - Trigger on this element.
+ */
+function dispatchChangeEvent(element) {
+    const changeEvent = new Event("change", { bubbles: true });
+    element.dispatchEvent(changeEvent);
+}
+
+// Register event listeners.
+document.querySelectorAll('input[type="text"]').forEach((input) => {
+    input.addEventListener("keyup", (event) => dispatchChangeEvent(event.target));
+});

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -16,5 +16,5 @@ function dispatchChangeEvent(element) {
 
 // Register event listeners.
 document.querySelectorAll('input[type="text"]').forEach((input) => {
-    input.addEventListener("input", (event) => dispatchChangeEvent(event.target));
+    input.addEventListener("input", (event) => dispatchChangeEvent(event.target)); // Save instantly on keypress/paste/etc.
 });


### PR DESCRIPTION
When I type in something in the field then close the window, the change
is lost and not saved. It only saves when I click out of the input
field.

This happens because IINA's injected javascript adds an event listener for the "change" event, which won't fire until the user presses Enter on an input field or clicks out of it. If the user types in text and then clicks out of the preferences tab (e.g. another IINA menu item) the changes are lost.

Fixing this by manually calling the "change" event on the "input" event which is fired on keyboard entry as well as cut/paste via the mouse.