### PR TITLE
Adding delay slider to preferences.

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -8,7 +8,8 @@
   "name": "File Name Search",
   "permissions": ["show-osd"],
   "preferenceDefaults": {
-    "auto_search": false,
+    "auto_delay": 0,
+    "auto_enabled": false,
     "regex": "",
     "url": ""
   },

--- a/src/preferences/preferences.html
+++ b/src/preferences/preferences.html
@@ -36,12 +36,22 @@
     </div>
     <div class="pref-section">
         <label>
-            <input type="checkbox" data-pref-key="auto_search" data-type="bool" />
+            <input type="checkbox" data-pref-key="auto_enabled" />
             Automatically open browser when playing a file
         </label>
         <p class="small secondary pref-help">
             Every time a new IINA window is opened or playing the next file a browser window will open. If unchecked you
             can do this manually in the plugins sidebar.
+        </p>
+    </div>
+    <div class="pref-section">
+        <label>
+            <input type="range" data-pref-key="auto_delay" min="0" max="10" />
+            Auto-open delay <span class="showValue"></span> second(s)
+        </label>
+        <p class="small secondary pref-help">
+            Show an overlay an wait these many seconds before actually opening a new browser window. IINA will lose
+            focus when the browser opens.
         </p>
     </div>
 </body>

--- a/src/preferences/preferences.html
+++ b/src/preferences/preferences.html
@@ -46,7 +46,7 @@
     </div>
     <div class="pref-section">
         <label>
-            <input type="range" data-pref-key="auto_delay" min="0" max="10" />
+            <input type="range" data-pref-key="auto_delay" min="0" max="10" step="1" />
             Auto-open delay <span class="showValue"></span>
         </label>
         <p class="small secondary pref-help">

--- a/src/preferences/preferences.html
+++ b/src/preferences/preferences.html
@@ -36,7 +36,7 @@
     </div>
     <div class="pref-section">
         <label>
-            <input type="checkbox" data-type="bool" data-pref-key="auto_search" />
+            <input type="checkbox" data-pref-key="auto_search" data-type="bool" />
             Automatically open browser when playing a file
         </label>
         <p class="small secondary pref-help">

--- a/src/preferences/preferences.html
+++ b/src/preferences/preferences.html
@@ -47,11 +47,11 @@
     <div class="pref-section">
         <label>
             <input type="range" data-pref-key="auto_delay" min="0" max="10" />
-            Auto-open delay <span class="showValue"></span> second(s)
+            Auto-open delay <span class="showValue"></span>
         </label>
         <p class="small secondary pref-help">
-            Show an overlay an wait these many seconds before actually opening a new browser window. IINA will lose
-            focus when the browser opens.
+            Show an overlay with a cancel button and wait these many seconds before actually opening a new browser
+            window. IINA will lose focus when the browser opens.
         </p>
     </div>
 </body>

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -64,13 +64,17 @@ function showValueInSpan(input) {
 document.querySelectorAll('input[type="text"]').forEach((input) => {
     input.addEventListener("input", (event) => dispatchChangeEvent(event.target)); // Save instantly on keypress/paste/etc.
     input.addEventListener("change", (event) => validateInput(event.target)); // Show/hide error messages.
-    setTimeout(() => validateInput(input), 100); // Validate on load after IINA calls preferences.get().
 });
 document.querySelectorAll('input[type="range"]').forEach((input) => {
-    input.addEventListener("input", (event) => showValueInSpan(event.target)); // Show value in <span>.
-    setTimeout(() => showValueInSpan(input), 100); // Show value on load after IINA calls preferences.get().
+    ["input", "change"].forEach((eventType) => {
+        input.addEventListener(eventType, (event) => showValueInSpan(event.target)); // Show value in <span>.
+    });
 });
 document.querySelector('input[data-pref-key="auto_enabled"]').addEventListener("change", (event) => {
     // Disable range if checkbox is unchecked.
     document.querySelector('input[data-pref-key="auto_delay"]').disabled = !event.target.checked;
+});
+document.querySelectorAll("input[data-pref-key]").forEach((input) => {
+    // Enable validators after IINA loads preferences.
+    setTimeout(() => dispatchChangeEvent(input), 100);
 });

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -55,7 +55,7 @@ function dispatchChangeEvent(element) {
 function showValueInSpan(input) {
     input.labels.forEach((label) => {
         label.querySelectorAll("span.showValue").forEach((span) => {
-            span.textContent = input.value;
+            span.textContent = `${input.value} second${input.value == 1 ? "" : "s"}`;
         });
     });
 }

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -75,6 +75,6 @@ document.querySelector('input[data-pref-key="auto_enabled"]').addEventListener("
     document.querySelector('input[data-pref-key="auto_delay"]').disabled = !event.target.checked;
 });
 document.querySelectorAll("input[data-pref-key]").forEach((input) => {
-    // Enable validators after IINA loads preferences.
+    // Call validators and the other event listeners on load after IINA calls preferences.get().
     setTimeout(() => dispatchChangeEvent(input), 100);
 });

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -70,3 +70,7 @@ document.querySelectorAll('input[type="range"]').forEach((input) => {
     input.addEventListener("input", (event) => showValueInSpan(event.target)); // Show value in <span>.
     setTimeout(() => showValueInSpan(input), 100); // Show value on load after IINA calls preferences.get().
 });
+document.querySelector('input[data-pref-key="auto_enabled"]').addEventListener("change", (event) => {
+    // Disable range if checkbox is unchecked.
+    document.querySelector('input[data-pref-key="auto_delay"]').disabled = !event.target.checked;
+});

--- a/src/preferences/preferences.js
+++ b/src/preferences/preferences.js
@@ -47,9 +47,26 @@ function dispatchChangeEvent(element) {
     element.dispatchEvent(changeEvent);
 }
 
+/**
+ * Show an input element's current value in a span with class "showValue".
+ *
+ * @param {Element} input - The input element to read the value from.
+ */
+function showValueInSpan(input) {
+    input.labels.forEach((label) => {
+        label.querySelectorAll("span.showValue").forEach((span) => {
+            span.textContent = input.value;
+        });
+    });
+}
+
 // Register event listeners.
 document.querySelectorAll('input[type="text"]').forEach((input) => {
     input.addEventListener("input", (event) => dispatchChangeEvent(event.target)); // Save instantly on keypress/paste/etc.
     input.addEventListener("change", (event) => validateInput(event.target)); // Show/hide error messages.
     setTimeout(() => validateInput(input), 100); // Validate on load after IINA calls preferences.get().
+});
+document.querySelectorAll('input[type="range"]').forEach((input) => {
+    input.addEventListener("input", (event) => showValueInSpan(event.target)); // Show value in <span>.
+    setTimeout(() => showValueInSpan(input), 100); // Show value on load after IINA calls preferences.get().
 });


### PR DESCRIPTION
New preference: delay for auto-open browser. This will give the user a chance to cancel opening a browser window via a future overlay with a cancel button.

Renaming `auto_search` to `auto_enabled`.

After looking at IINA's source, there's no need for `data-type` attribute for checkboxes.

