### PR TITLE
postMessageAck and onMessageAck

### DIFF
--- a/src/entry.cjs
+++ b/src/entry.cjs
@@ -2,7 +2,7 @@
  * Main entrypoint.
  */
 
-const { getFileNameSansExt } = require("./lib.cjs");
+const { getFileNameSansExt, postMessageAck } = require("./lib.cjs");
 
 /**
  * Event handler for iina.window-loaded.
@@ -21,42 +21,12 @@ function onWindowLoaded() {
 function onFileLoaded(fileUrl) {
     iina.console.log("onFileLoaded");
 
-    if (iina.preferences.get("auto_search") !== true) {
-        iina.console.debug("auto_search not enabled, noop");
-        return;
-    }
-
-    const prefsUrl = iina.preferences.get("url");
-    if (!prefsUrl) {
-        iina.console.error("PLUGIN ERROR: No URL specified");
-        iina.core.osd("PLUGIN ERROR: No URL specified");
-        return;
-    } else if (!prefsUrl.includes("%s")) {
-        iina.console.error("PLUGIN ERROR: %s is missing from url");
-        iina.core.osd("PLUGIN ERROR: %s is missing from url");
-        return;
-    }
-
-    let videoName = getFileNameSansExt(fileUrl);
-    const prefsRegex = iina.preferences.get("regex");
-    if (prefsRegex) {
-        let regex;
-        try {
-            regex = new RegExp(prefsRegex);
-        } catch (exc) {
-            iina.console.error(`PLUGIN ERROR: invalid regex: ${exc.message}`);
-            iina.core.osd("PLUGIN ERROR: invalid regex");
-            return;
-        }
-        const match = videoName.match(regex);
-        if (!match) {
-            iina.console.debug("regex did not match, noop");
-            return;
-        }
-        videoName = match[0];
-    }
-
-    // iina.utils.open(prefsUrl.replace("%s", videoName));
+    // Update sidebar.
+    postMessageAck("sidebar", "file-loaded", {
+        fileNameSansExt: getFileNameSansExt(fileUrl),
+        prefsRegex: iina.preferences.get("regex"),
+        prefsUrl: iina.preferences.get("url"),
+    });
 }
 
 // Menu items.

--- a/src/lib.cjs
+++ b/src/lib.cjs
@@ -21,7 +21,47 @@ function getFileNameSansExt(url) {
     return decodeURI(name);
 }
 
+/**
+ * Guarantee that a message is sent to the target web view.
+ *
+ * There is a race condition when a message is sent to a sidebar that is not done initializing. This function sets a timer
+ * that re-sends the message if the sidebar does not acknowledge receipt of the message.
+ *
+ * @param {string} target - "sidebar" or "overlay".
+ * @param {string} name - Message name passed to postMessage().
+ * @param {any} payload - Message payload passed to postMessage().
+ * @param {number} retryIn - Retry in these many ms.
+ * @param {number} timeout - Stop retrying after these many ms.
+ * @param {IINA.API} _iina - iina object, for testing.
+ */
+function postMessageAck(target, name, payload, retryIn = 100, timeout = 1000, _iina = iina) {
+    _iina.console.log(`postMessageAck(${target}, ${name}, ...)`);
+    const namespace = target === "sidebar" ? _iina.sidebar : _iina.overlay;
+    let timeoutId;
+
+    // Setup ack listener.
+    namespace.onMessage(`${name}::ack`, () => {
+        _iina.console.log(`${target} acknowledged ${name} message`);
+        clearTimeout(timeoutId);
+    });
+
+    // Setup re-send timer.
+    timeoutId = setTimeout(() => {
+        timeout -= retryIn;
+        if (timeout < 1) {
+            _iina.console.error(`${target} did not respond for ${name}, timed out, aborting message`);
+            return;
+        }
+        _iina.console.warn(`${target} did not respond for ${name}, re-sending`);
+        postMessageAck(target, name, payload, retryIn, timeout, _iina);
+    }, retryIn);
+
+    // Send the message.
+    namespace.postMessage(name, payload);
+}
+
 // Export.
 module.exports = {
     getFileNameSansExt,
+    postMessageAck,
 };

--- a/src/web/lib-web.cjs
+++ b/src/web/lib-web.cjs
@@ -99,15 +99,31 @@ function showHideError(element, errorMessage) {
     }
 }
 
+/**
+ * Acknowledge to the sender that the message has been received.
+ *
+ * @param {string} name - Message name passed to onMessage().
+ * @param {Function} callback - Caller's callback function meant for onMessage().
+ * @param {IINA.API} _iina - iina object, for testing.
+ */
+function onMessageAck(name, callback, _iina = iina) {
+    _iina.onMessage(name, (...args) => {
+        _iina.postMessage(`${name}::ack`);
+        callback(...args);
+    });
+}
+
 // Export.
 if (typeof module === "object") {
     module.exports = {
         validateUrl,
         validateRegex,
         showHideError,
+        onMessageAck,
     };
 } else {
     window.validateUrl = validateUrl;
     window.validateRegex = validateRegex;
     window.showHideError = showHideError;
+    window.onMessageAck = onMessageAck;
 }

--- a/src/web/sidebar/sidebar.cjs
+++ b/src/web/sidebar/sidebar.cjs
@@ -58,3 +58,8 @@ openBrowserForm.addEventListener("submit", (event) => {
     event.preventDefault(); // Don't clear the form.
     if (!openBrowserButton.disabled) iina.postMessage("open-browser", { search: searchInput.value });
 });
+
+/**
+ * Receive file-loaded message from plugin.
+ */
+window.onMessageAck("file-loaded", () => {}); // TODO

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "@jest/globals";
-import { getFileNameSansExt } from "../src/lib.cjs";
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getFileNameSansExt, postMessageAck } from "../src/lib.cjs";
 
 describe("getFileNameSansExt", () => {
     test.each([
@@ -16,5 +16,98 @@ describe("getFileNameSansExt", () => {
         ["", ""],
     ])("getFileNameSansExt::%s:%s", (filePath, basename) => {
         expect(getFileNameSansExt(filePath)).toEqual(basename);
+    });
+});
+
+describe("postMessageAck", () => {
+    let logs = [];
+    let onMessageRegistered = new Map();
+    let postMessageSent = [];
+    const iina = {
+        console: {
+            log: (message) => logs.push(message),
+            warn: (message) => logs.push(message),
+            error: (message) => logs.push(message),
+        },
+        sidebar: {
+            onMessage: (name, callback) => onMessageRegistered.set(name, callback),
+            postMessage: (name) => postMessageSent.push(name),
+        },
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        logs = [];
+        onMessageRegistered = new Map();
+        postMessageSent = [];
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test("one attempt", () => {
+        // Send initial message.
+        postMessageAck("sidebar", "test", {}, 100, 200, iina);
+        expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+        expect(postMessageSent.pop()).toEqual("test");
+        // Remote acknowledges.
+        onMessageRegistered.get("test::ack")();
+        onMessageRegistered.delete("test::ack");
+        expect(logs.pop()).toEqual("sidebar acknowledged test message");
+        // Confirm timer cancelled.
+        jest.advanceTimersByTime(2000);
+        expect(logs).toHaveLength(0);
+        expect(onMessageRegistered.size).toEqual(0);
+        expect(postMessageSent).toHaveLength(0);
+    });
+
+    test("two attempts", () => {
+        // Send initial message.
+        postMessageAck("sidebar", "test", {}, 100, 200, iina);
+        expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+        expect(postMessageSent.pop()).toEqual("test");
+        // Advance timer to second attempt.
+        jest.advanceTimersByTime(99);
+        expect(logs).toHaveLength(0);
+        expect(postMessageSent).toHaveLength(0);
+        jest.advanceTimersByTime(1);
+        expect(logs.shift()).toEqual("sidebar did not respond for test, re-sending");
+        expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+        expect(postMessageSent.pop()).toEqual("test");
+        // Remote acknowledges.
+        onMessageRegistered.get("test::ack")();
+        onMessageRegistered.delete("test::ack");
+        expect(logs.pop()).toEqual("sidebar acknowledged test message");
+        // Confirm timer cancelled.
+        jest.advanceTimersByTime(2000);
+        expect(logs).toHaveLength(0);
+        expect(onMessageRegistered.size).toEqual(0);
+        expect(postMessageSent).toHaveLength(0);
+    });
+
+    test.each([2, 3])("timeout::attempts=%d", (attempts) => {
+        // Send initial message.
+        postMessageAck("sidebar", "test", {}, 100, attempts === 2 ? 200 : 201, iina);
+        expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+        // Advance timer to second attempt.
+        jest.advanceTimersByTime(100);
+        expect(logs.shift()).toEqual("sidebar did not respond for test, re-sending");
+        expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+        // Advance timer to third attempt.
+        jest.advanceTimersByTime(100);
+        if (attempts === 2) {
+            // Timeout before third attempt.
+            expect(logs.pop()).toEqual("sidebar did not respond for test, timed out, aborting message");
+        } else {
+            expect(logs.shift()).toEqual("sidebar did not respond for test, re-sending");
+            expect(logs.pop()).toEqual("postMessageAck(sidebar, test, ...)");
+            jest.advanceTimersByTime(100);
+            expect(logs.pop()).toEqual("sidebar did not respond for test, timed out, aborting message");
+        }
+        // Confirm no more timers.
+        jest.advanceTimersByTime(2000);
+        expect(logs).toHaveLength(0);
     });
 });


### PR DESCRIPTION
There is a race condition when entry tries to post messages to the sidebar. Sometimes the message is sent before the sidebar is done initializing. Mitigating this with wrapper functions that acknowledge messages.

Re-defining onFileLoaded to just send messages to the sidebar. Will eventually do the same with an overlay.